### PR TITLE
DPS-1475: added .drone.yml file to allow publishing to ACP Artifactory…

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,33 @@
+pipeline:
+
+  test:
+    image: node:8
+    secrets:
+      - npm_config__auth
+      - npm_config_registry
+      - npm_config_email
+    environment:
+      - NPM_CONFIG_ALWAYS_AUTH=true
+    commands:
+      - npm i
+      - npm test
+    when:
+      event: [push, tag]
+
+  publish_to_artifactory:
+    image: node:8
+    secrets:
+      - npm_config__auth
+      - npm_config_registry
+      - npm_config_email
+    environment:
+      - NPM_CONFIG_ALWAYS_AUTH=true
+    commands:
+      - npm publish
+    when:
+      event: [tag]
+
+matrix:
+  NPM_CONFIG_USERNAME:
+    - regt-build-bot
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A stub service to mock RESTful communication between Electronic Visa Waiver Customer and Caseworker applications",
   "main": "index.js",
   "scripts": {
-    "test": "./bin/mocha",
+    "test": "mocha",
     "lint": "./node_modules/.bin/eslint ."
   },
   "author": "Home Office Digital",
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "colour": "^0.7.1",
-    "dyson": "^0.10.0"
+    "dyson": "^0.10.0",
+    "mocha": "^2.5.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "eslint-plugin-mocha": "^3.0.0",
-    "mocha": "^2.5.3",
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0"


### PR DESCRIPTION
… on tag, and tweaked package.json to make that actually work.

This will allow developers to npm install the latest version of evw-integration-stub (which includes [recent API changes to support update-passport-image](https://github.com/UKHomeOffice/evw-integration-service/pull/141)) when developing EVW Customer HOF locally.

https://jira.digital.homeoffice.gov.uk/browse/DPS-1475